### PR TITLE
Bump Flink and JUnit versions, Mark unneeded class as @Deprecated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ under the License.
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>5.11.4</junit.version>
         <assertj.version>3.16.1</assertj.version>
 	    <artifactrepo.url>https://mvnrepository.com/artifact/com.amazonaws/aws-kinesisanalytics-runtime</artifactrepo.url>
     </properties>
@@ -81,8 +81,8 @@ under the License.
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.8.3</flink.version>
+        <flink.version>1.20.0</flink.version>
         <scala.binary.version>2.11</scala.binary.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -75,7 +75,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
-            <version>2.7.9-4.0</version>
+            <version>2.14.2-17.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/amazonaws/services/kinesisanalytics/flink/serialization/POJODeserializationSchema.java
+++ b/src/main/java/com/amazonaws/services/kinesisanalytics/flink/serialization/POJODeserializationSchema.java
@@ -24,6 +24,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 
 import java.io.IOException;
 
+/**
+ * @deprecated This is not needed for KinesisAnalyticsRuntime.
+ */
+@Deprecated
 public class POJODeserializationSchema<T> implements DeserializationSchema<T> {
     private final ObjectMapper mapper = new ObjectMapper();
     private final Class<T> clazz;

--- a/src/test/java/com/amazonaws/services/kinesisanalytics/runtime/KinesisAnalyticsRuntimeTest.java
+++ b/src/test/java/com/amazonaws/services/kinesisanalytics/runtime/KinesisAnalyticsRuntimeTest.java
@@ -18,7 +18,7 @@
 
 package com.amazonaws.services.kinesisanalytics.runtime;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;


### PR DESCRIPTION
*Description of changes:*
- Bump Flink version to the latest version. This is not packaged in the final artifact..
- Bump Junit4 to JUnit5. Bump from `4.13.1` to `5.11.4`. This is not packaged in the final artifact
- Marked `POJODeserializationSchema` as `@Deprecated` as this is not needed. Not removing as this requires a major version bump.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
